### PR TITLE
fix(docs): correct base scan URL

### DIFF
--- a/pages/docs/bounties.mdx
+++ b/pages/docs/bounties.mdx
@@ -20,6 +20,6 @@ The redemption contract is WIP and will be posted in discord after initial testi
 
 [0x0000000000b2AF9d57d12F011591abE3F6CE50c0](https://opensea.io/collection/nani-bounties-4)
 
-Bounties are issued by the [OS Admin](0x999657A41753b8E69C66e7b1A8E37d513CB44E1C), until [the DAO](https://basescan.io/address/0xDa000000000000d2885F108500803dfBAaB2f2aA#code) on Base is configured following the end of the beta.
+Bounties are issued by the [OS Admin](0x999657A41753b8E69C66e7b1A8E37d513CB44E1C), until [the DAO](https://basescan.org/address/0xDa000000000000d2885F108500803dfBAaB2f2aA#code) on Base is configured following the end of the beta.
 
 The NANI OS agent account (0x466d3E0E6D661d6E7626e9dea93c460BD4e15B40) will also provide bounties as well as tipping. These updates will also be published in discord when ready.


### PR DESCRIPTION
Right now the link out to the contract has a dead link